### PR TITLE
fix: change presidential email

### DIFF
--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -139,7 +139,7 @@ export default function Footer() {
                         <ul className="space-y-2">
                             <li className="text-gray-400 hover:text-white">
                                 <Link
-                                    href="mailto:president@texasacm.org"
+                                    href="mailto:pres@texasacm.org"
                                     className="flex items-center gap-2"
                                 >
                                     <Mail size={16} className="min-h-4 min-w-4" />

--- a/components/join-section.tsx
+++ b/components/join-section.tsx
@@ -63,7 +63,7 @@ export default function JoinSection() {
                             <p className="text-sm text-gray-500">
                                 Questions about membership?{' '}
                                 <Link
-                                    href="mailto:president@texasacm.org"
+                                    href="mailto:pres@texasacm.org"
                                     className="text-primary hover:underline"
                                 >
                                     Contact us


### PR DESCRIPTION
Changes presidential email from president@texasacm.org to pres@texasacm.org
Closes #11 