### PR TITLE
fix: implement email signup with Mailchimp

### DIFF
--- a/components/EmailSignupForm.tsx
+++ b/components/EmailSignupForm.tsx
@@ -10,6 +10,7 @@ import {
     FormMessage,
 } from '@/components/ui/form';
 import { useForm } from 'react-hook-form';
+import { toast } from '@/components/ui/use-toast';
 
 type Inputs = { email: string };
 
@@ -17,7 +18,50 @@ export default function EmailSignupForm() {
     const methods = useForm<Inputs>({ defaultValues: { email: '' } });
 
     const onSubmit = (data: Inputs) => {
-        console.log('got email:', data.email);
+        // Create and submit a form exactly like the old website
+        const form = document.createElement('form');
+        form.action =
+            'https://texasacm.us11.list-manage.com/subscribe/post?u=79fed73196d8c1087cd42c541&id=88d0a26018';
+        form.method = 'post';
+        form.target = '_blank';
+        form.noValidate = true;
+        form.style.display = 'none';
+
+        // Email field
+        const emailInput = document.createElement('input');
+        emailInput.type = 'email';
+        emailInput.name = 'EMAIL';
+        emailInput.value = data.email;
+        emailInput.className = 'required email';
+
+        // Honeypot field (anti-bot) - exactly like the old website
+        const honeypotDiv = document.createElement('div');
+        honeypotDiv.style.position = 'absolute';
+        honeypotDiv.style.left = '-5000px';
+        honeypotDiv.setAttribute('aria-hidden', 'true');
+        const honeypotInput = document.createElement('input');
+        honeypotInput.type = 'text';
+        honeypotInput.name = 'b_79fed73196d8c1087cd42c541_88d0a26018';
+        honeypotInput.tabIndex = -1;
+        honeypotInput.value = '';
+        honeypotDiv.appendChild(honeypotInput);
+
+        form.appendChild(emailInput);
+        form.appendChild(honeypotDiv);
+        document.body.appendChild(form);
+
+        // Submit and clean up
+        form.submit();
+        document.body.removeChild(form);
+
+        // Show a quick toast notification
+        toast({
+            title: 'Opening Mailchimp...',
+            description: 'A new tab will open to complete your subscription.',
+        });
+
+        // Reset the form
+        methods.reset();
     };
 
     return (
@@ -26,6 +70,13 @@ export default function EmailSignupForm() {
                 <FormField
                     control={methods.control}
                     name="email"
+                    rules={{
+                        required: 'Email address is required',
+                        pattern: {
+                            value: /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i,
+                            message: 'Please enter a valid email address',
+                        },
+                    }}
                     render={({ field }) => (
                         <FormItem>
                             <FormLabel>Email address</FormLabel>


### PR DESCRIPTION
Closes #6 
Mimics the old website's functionality. It's not perfect, but it works for now.

The functionality of the old website is that you type in your email, click submit, and it opens a new tab on Mailchimp in your browser saying you successfully subscribed (while directing you to a page with the option to unsubscribe if you changed your mind). 